### PR TITLE
Remove application attrs

### DIFF
--- a/circularprogressbar/src/main/AndroidManifest.xml
+++ b/circularprogressbar/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mikhaellopez.circularprogressbar">
 
-    <application
-        android:allowBackup="true"
-        android:supportsRtl="true"/>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
It brings build failure to merger.
This can be avoided with `tools:replace` but that is :/
and library do not need these attrs afaik.

```
*****/app/src/debug/AndroidManifest.xml:14:9-36 Error:
	Attribute application@allowBackup value=(false) from AndroidManifest.xml:14:9-36
	is also present at [com.mikhaellopez:circularprogressbar:1.0.0] AndroidManifest.xml:12:9-35 value=(true).
	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:5:5-20:19 to override.
*****/app/src/debug/AndroidManifest.xml:17:9-36 Error:
	Attribute application@supportsRtl value=(false) from AndroidManifest.xml:17:9-36
	is also present at [com.mikhaellopez:circularprogressbar:1.0.0] AndroidManifest.xml:13:9-35 value=(true).
	Suggestion: add 'tools:replace="android:supportsRtl"' to <application> element at AndroidManifest.xml:5:5-20:19 to override.
```