### PR TITLE
Use method TypedArray#getColor to obtain colors from XML attributes

### DIFF
--- a/circularprogressbar/src/main/java/com/mikhaellopez/circularprogressbar/CircularProgressBar.java
+++ b/circularprogressbar/src/main/java/com/mikhaellopez/circularprogressbar/CircularProgressBar.java
@@ -61,8 +61,8 @@ public class CircularProgressBar extends View {
             strokeWidth = typedArray.getDimension(R.styleable.CircularProgressBar_cpb_progressbar_width, strokeWidth);
             backgroundStrokeWidth = typedArray.getDimension(R.styleable.CircularProgressBar_cpb_background_progressbar_width, backgroundStrokeWidth);
             // Color
-            color = typedArray.getInt(R.styleable.CircularProgressBar_cpb_progressbar_color, color);
-            backgroundColor = typedArray.getInt(R.styleable.CircularProgressBar_cpb_background_progressbar_color, backgroundColor);
+            color = typedArray.getColor(R.styleable.CircularProgressBar_cpb_progressbar_color, color);
+            backgroundColor = typedArray.getColor(R.styleable.CircularProgressBar_cpb_background_progressbar_color, backgroundColor);
         } finally {
             typedArray.recycle();
         }


### PR DESCRIPTION
I planned to use your library in one of my project, but I encountered a problem: Currently it is not possible to use a `ColorStateList` as the `CircularProgressBar`'s (background) color. This pull request resolves this limitation and allows to use e.g. `?android:attr/textColorPrimary` as a progress bar's color.