### PR TITLE
cpb_progress attribute takes in a float

### DIFF
--- a/circularprogressbar/src/main/res/values/attrs.xml
+++ b/circularprogressbar/src/main/res/values/attrs.xml
@@ -1,6 +1,6 @@
 <resources>
     <declare-styleable name="CircularProgressBar">
-        <attr name="cpb_progress" format="integer" />
+        <attr name="cpb_progress" format="float" />
         <attr name="cpb_progress_max" format="integer" />
         <attr name="cpb_indeterminate_mode" format="boolean" />
         <attr name="cpb_progressbar_color" format="color" />


### PR DESCRIPTION
Then cpb_progress backing property is a `float`, and the only place it is restricted to an integer is from the xml attributes.  This will allow using floats in the xml as well